### PR TITLE
Restrict dataset uploading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Features:
 
 To allow users to upload datasets before becoming members of organizations, this plugin requires datasets without an owner organization to be public.
 
-Also set the following config options to allow uploads:
+Also set the following config options to allow uploads::
 
     ckan.auth.create_unowned_dataset = true
     ckan.auth.create_dataset_if_not_in_organization = true

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,14 @@ Features:
 - de-emphasise Organisations and Groups
 - add a financial year tag
 
+To allow users to upload datasets before becoming members of organizations, this plugin requires datasets without an owner organization to be public.
+
+Also set the following config options to allow uploads:
+
+    ckan.auth.create_unowned_dataset = true
+    ckan.auth.create_dataset_if_not_in_organization = true
+
+
 ------------
 Installation
 ------------

--- a/ckanext/satreasury/fanstatic/satreasury_dataset_visibility.js
+++ b/ckanext/satreasury/fanstatic/satreasury_dataset_visibility.js
@@ -1,6 +1,7 @@
 /* Dataset visibility toggler
  * When no organization is selected in the org dropdown then set visibility to
- * public always and disable dropdown
+ * private and disable dropdown.
+ * Default to Public when an organization is selected.
  */
 this.ckan.module('satreasury_dataset_visibility', function ($, _) {
   return {

--- a/ckanext/satreasury/fanstatic/satreasury_dataset_visibility.js
+++ b/ckanext/satreasury/fanstatic/satreasury_dataset_visibility.js
@@ -1,0 +1,33 @@
+/* Dataset visibility toggler
+ * When no organization is selected in the org dropdown then set visibility to
+ * public always and disable dropdown
+ */
+this.ckan.module('satreasury_dataset_visibility', function ($, _) {
+  console.log("installing");
+  return {
+    currentValue: false,
+    options: {
+      currentValue: null
+    },
+    initialize: function() {
+      $.proxyAll(this, /_on/);
+      this.options.organizations = $('#field-organizations'),
+      this.options.visibility = $('#field-private-satreasury'),
+      this.options.currentValue = this.options.visibility.val();
+      this.options.organizations.on('change', this._onOrganizationChange);
+      this._onOrganizationChange();
+    },
+    _onOrganizationChange: function() {
+      var value = this.options.organizations.val();
+      if (value) {
+        this.options.visibility
+          .prop('disabled', false)
+          .val('False');
+      } else {
+        this.options.visibility
+          .prop('disabled', true)
+          .val('True');
+      }
+    }
+  };
+});

--- a/ckanext/satreasury/fanstatic/satreasury_dataset_visibility.js
+++ b/ckanext/satreasury/fanstatic/satreasury_dataset_visibility.js
@@ -3,7 +3,6 @@
  * public always and disable dropdown
  */
 this.ckan.module('satreasury_dataset_visibility', function ($, _) {
-  console.log("installing");
   return {
     currentValue: false,
     options: {

--- a/ckanext/satreasury/plugin.py
+++ b/ckanext/satreasury/plugin.py
@@ -149,6 +149,10 @@ class SATreasuryDatasetPlugin(plugins.SingletonPlugin, tk.DefaultDatasetForm):
                 tk.get_validator('ignore_missing'),
                 tk.get_converter('convert_to_extras')
             ],
+            'private': [
+                tk.get_validator('ignore_missing'),
+                tk.get_validator('boolean_validator'),
+            ],
         })
         return schema
 

--- a/ckanext/satreasury/plugin.py
+++ b/ckanext/satreasury/plugin.py
@@ -1,3 +1,16 @@
+"""
+
+Core plugin for the South African Budget Portal vulekamali
+
+- Adds fields to datasets
+  - provinces
+  - financial year
+  - sphere (of government)
+  - methodology
+- Adds fields to organizations like contact details
+- Disables non-sysadmin access to /users which lists usernames
+- Disallows non-sysadmins from making datasets without an owner organization public.
+"""
 import datetime
 
 import ckan.plugins as plugins
@@ -379,8 +392,6 @@ def auth_user_list(context, data_dict=None):
 
 
 def auth_package_create(context, data_dict=None):
-    log.info("package_create %r %r", context, data_dict)
-
     skip_custom_auth = not data_dict
     if not skip_custom_auth:
         dataset_has_org = data_dict.get('owner_org', None)
@@ -397,8 +408,6 @@ def auth_package_create(context, data_dict=None):
 
 
 def auth_package_update(context, data_dict=None):
-    log.info("package_update %r %r", context, data_dict)
-
     skip_custom_auth = not data_dict
     if not skip_custom_auth:
         dataset_has_org = data_dict.get('owner_org', None)

--- a/ckanext/satreasury/plugin.py
+++ b/ckanext/satreasury/plugin.py
@@ -378,11 +378,17 @@ def auth_package_create(context, data_dict=None):
     # If they're just viewing the new creation form
     # or they're creating a private dataset, fall back to ckan auth
     log.info("package_create %r %r", context, data_dict)
-    if data_dict is None or data_dict.get('private') == 'True':
+    if data_dict is None \
+       or not data_dict \
+       or data_dict.get('private') == 'True':
         return ckan_auth.create.package_create(context, data_dict)
 
     # If they're not adding a dataset to an org but they're setting it public, reject
-    if data_dict.get('owner_org', None) and data_dict('private', 'False').lower() == 'true':
+    dataset_has_org = data_dict.get('owner_org', None)
+    dataset_is_public = data_dict.get('private', 'true').lower() == 'true'
+    if not dataset_has_org and dataset_is_public:
+        log.info("rejecting package_create: dataset_has_org=%r, dataset_is_public=%r",
+                 dataset_has_org, dataset_is_public)
         return {
             'success': False,
             'msg': 'Cannot create a public dataset without an organization'

--- a/ckanext/satreasury/plugin.py
+++ b/ckanext/satreasury/plugin.py
@@ -383,7 +383,7 @@ def auth_package_create(context, data_dict=None):
 
     skip_custom_auth = not data_dict
     if not skip_custom_auth:
-        dataset_has_org = tk.asbool(data_dict.get('owner_org', None))
+        dataset_has_org = data_dict.get('owner_org', None)
         dataset_is_public = not tk.asbool(data_dict.get('private', 'true'))
         if not dataset_has_org and dataset_is_public:
             log.info("rejecting package_create: dataset_has_org=%r, dataset_is_public=%r",
@@ -401,7 +401,7 @@ def auth_package_update(context, data_dict=None):
 
     skip_custom_auth = not data_dict
     if not skip_custom_auth:
-        dataset_has_org = tk.asbool(data_dict.get('owner_org', None))
+        dataset_has_org = data_dict.get('owner_org', None)
         dataset_is_public = not tk.asbool(data_dict.get('private', 'true'))
         if not dataset_has_org and dataset_is_public:
             log.info("rejecting package_update: dataset_has_org=%r, dataset_is_public=%r",

--- a/ckanext/satreasury/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/satreasury/templates/package/snippets/package_basic_fields.html
@@ -19,6 +19,8 @@
   {{ form.markdown('notes', id='field-notes', label=_('Description'), placeholder=_('eg. Some useful notes about the data'), value=data.notes, error=errors.notes) }}
 {% endblock %}
 
+{{ form.markdown('methodology', label=_('Methodology'), id='field-methodology', placeholder=_('What methodology did you follow when gathering and analysing the data? Include things that will help others understand the possible limitations to your dataset or analysis. What should they bear in mind when working with your data?'), value=data.methodology, error=errors.methodology) }}
+
 {% block package_basic_fields_tags %}
   {% set tag_attrs = {'data-module': 'autocomplete', 'data-module-tags': '', 'data-module-source': '/api/2/util/tag/autocomplete?incomplete=?'} %}
   {{ form.input('tag_string', id='field-tags', label=_('Tags'), placeholder=_('eg. economy, mental health, government'), value=data.tag_string, error=errors.tags, classes=['control-full'], attrs=tag_attrs) }}

--- a/ckanext/satreasury/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/satreasury/templates/package/snippets/package_basic_fields.html
@@ -1,5 +1,118 @@
-{% ckan_extends %}
+{% import 'macros/form.html' as form %}
 
-{% block package_basic_fields_custom %}
-  {{ form.markdown('methodology', label=_('Methodology'), id='field-methodology', placeholder=_('What methodology did you follow when gathering and analysing the data? Include things that will help others understand the possible limitations to your dataset or analysis. What should they bear in mind when working with your data?'), value=data.methodology, error=errors.methodology) }}
+{% block package_basic_fields_title %}
+  {{ form.input('title', id='field-title', label=_('Title'), placeholder=_('eg. A descriptive title'), value=data.title, error=errors.title, classes=['control-full', 'control-large'], attrs={'data-module': 'slug-preview-target'}) }}
+{% endblock %}
+
+{% block package_basic_fields_url %}
+  {% set prefix = h.url_for(controller='package', action='read', id='') %}
+  {% set domain = h.url_for(controller='package', action='read', id='', qualified=true) %}
+  {% set domain = domain|replace("http://", "")|replace("https://", "") %}
+  {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain, 'data-module-placeholder': '<dataset>'} %}
+
+  {{ form.prepend('name', id='field-name', label=_('URL'), prepend=prefix, placeholder=_('eg. my-dataset'), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
+{% endblock %}
+
+{% block package_basic_fields_custom %}{% endblock %}
+
+{% block package_basic_fields_description %}
+  {{ form.markdown('notes', id='field-notes', label=_('Description'), placeholder=_('eg. Some useful notes about the data'), value=data.notes, error=errors.notes) }}
+{% endblock %}
+
+{% block package_basic_fields_tags %}
+  {% set tag_attrs = {'data-module': 'autocomplete', 'data-module-tags': '', 'data-module-source': '/api/2/util/tag/autocomplete?incomplete=?'} %}
+  {{ form.input('tag_string', id='field-tags', label=_('Tags'), placeholder=_('eg. economy, mental health, government'), value=data.tag_string, error=errors.tags, classes=['control-full'], attrs=tag_attrs) }}
+{% endblock %}
+
+{% block package_basic_fields_license %}
+<div class="control-group">
+  {% set error = errors.license_id %}
+  <label class="control-label" for="field-license">{{ _("License") }}</label>
+  <div class="controls">
+    <select id="field-license" name="license_id" data-module="autocomplete">
+      {% set existing_license_id = data.get('license_id') %}
+      {% for license_id, license_desc in h.license_options(existing_license_id) %}
+        <option value="{{ license_id }}" {% if existing_license_id == license_id %}selected="selected"{% endif %}>{{ license_desc }}</option>
+      {% endfor %}
+    </select>
+    {% if error %}<span class="error-block">{{ error }}</span>{% endif %}
+    <span class="info-block info-inline">
+      <i class="fa fa-info-circle"></i>
+      {% trans %}
+        License definitions and additional information can be found
+        at <a href="http://opendefinition.org/licenses/">opendefinition.org</a>
+      {% endtrans %}
+    </span>
+  </div>
+</div>
+{% endblock %}
+
+{% block package_basic_fields_org %}
+  {# if we have a default group then this wants remembering #}
+  {% if data.group_id %}
+    <input type="hidden" name="groups__0__id" value="{{ data.group_id }}" />
+  {% endif %}
+
+  {% set dataset_is_draft = data.get('state', 'draft').startswith('draft') or data.get('state', 'none') ==  'none' %}
+  {% set dataset_has_organization = data.owner_org or data.group_id %}
+  {% set organizations_available = h.organizations_available('create_dataset') %}
+  {% set user_is_sysadmin = h.check_access('sysadmin') %}
+  {% set show_organizations_selector = organizations_available %}
+  {% set show_visibility_selector = dataset_has_organization or (organizations_available and (user_is_sysadmin or dataset_is_draft)) %}
+
+  {% if show_organizations_selector and show_visibility_selector %}
+    <div data-module="dataset-visibility">
+  {% endif %}
+
+  {% if show_organizations_selector %}
+    {% set existing_org = data.owner_org or data.group_id %}
+    <div class="control-group">
+      <label for="field-organizations" class="control-label">{{ _('Organization') }}</label>
+      <div class="controls">
+        <select id="field-organizations" name="owner_org" data-module="autocomplete">
+          {% if h.check_config_permission('create_unowned_dataset') %}
+             <option value="" {% if not selected_org and data.id %} selected="selected" {% endif %}>{{ _('No organization') }}</option>
+          {% endif %}
+          {% for organization in organizations_available %}
+            {# get out first org from users list only if there is not an existing org #}
+            {% set selected_org = (existing_org and existing_org == organization.id) or (not existing_org and not data.id and organization.id == organizations_available[0].id) %}
+            <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ organization.display_name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+  {% endif %}
+
+  {% if show_visibility_selector %}
+    {% block package_metadata_fields_visibility %}
+      <div class="control-group">
+        <label for="field-private" class="control-label">{{ _('Visibility') }}</label>
+        <div class="controls">
+          <select id="field-private" name="private">
+            {% for option in [('True', _('Private')), ('False', _('Public'))] %}
+            <option value="{{ option[0] }}" {% if option[0] == data.private|trim %}selected="selected"{% endif %}>{{ option[1] }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+    {% endblock %}
+  {% endif %}
+
+  {% if show_organizations_selector and show_visibility_selector %}
+    </div>
+  {% endif %}
+
+
+  {% if data.id and h.check_access('package_delete', {'id': data.id}) and data.state != 'active' %}
+    <div class="control-group">
+      <label for="field-state" class="control-label">{{ _('State') }}</label>
+      <div class="controls">
+        <select id="field-state" name="state">
+          <option value="active" {% if data.get('state', 'none') == 'active' %} selected="selected" {% endif %}>{{ _('Active') }}</option>
+          <option value="deleted" {% if data.get('state', 'none') == 'deleted' %} selected="selected" {% endif %}>{{ _('Deleted') }}</option>
+        </select>
+      </div>
+    </div>
+  {% endif %}
+
 {% endblock %}

--- a/ckanext/satreasury/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/satreasury/templates/package/snippets/package_basic_fields.html
@@ -98,6 +98,8 @@
         </div>
       </div>
     {% endblock %}
+  {% else %}
+    <input name="private" type="hidden" value="True" />
   {% endif %}
 
   {% if show_organizations_selector and show_visibility_selector %}

--- a/ckanext/satreasury/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/satreasury/templates/package/snippets/package_basic_fields.html
@@ -63,7 +63,7 @@
   {% set show_visibility_selector = dataset_has_organization or (organizations_available and (user_is_sysadmin or dataset_is_draft)) %}
 
   {% if show_organizations_selector and show_visibility_selector %}
-    <div data-module="dataset-visibility">
+    <div data-module="satreasury_dataset_visibility">
   {% endif %}
 
   {% if show_organizations_selector %}
@@ -87,11 +87,13 @@
 
   {% if show_visibility_selector %}
     {% block package_metadata_fields_visibility %}
+      {% resource 'satreasury/satreasury_dataset_visibility.js' %}
+
       <div class="control-group">
-        <label for="field-private" class="control-label">{{ _('Visibility') }}</label>
+        <label for="field-private-satreasury" class="control-label">{{ _('Visibility') }}</label>
         <div class="controls">
-          <select id="field-private" name="private">
-            {% for option in [('True', _('Private')), ('False', _('Public'))] %}
+          <select id="field-private-satreasury" name="private">
+            {% for option in [('False', _('Public')), ('True', _('Private'))] %}
             <option value="{{ option[0] }}" {% if option[0] == data.private|trim %}selected="selected"{% endif %}>{{ option[1] }}</option>
             {% endfor %}
           </select>


### PR DESCRIPTION
Datasets without an organization are required to be private. They can only be made public by a sysadmin or when adding them to an organization.

This is to encourage uploads (and we can figure out the rest later) and place the onus of not uploading malicious content on approved organizations.